### PR TITLE
fix: add transaction queue to prevent nonce conflicts

### DIFF
--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -2,9 +2,13 @@ import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider(process.env.RPC_PROVIDER_URL!);
 
-export function createSigner(privateKey: string) {
-  const wallet = new ethers.Wallet(privateKey);
-  return wallet.connect(provider);
+let signer: ethers.Wallet | null = null;
+
+export function getSigner(): ethers.Wallet {
+  if (!signer) {
+    signer = new ethers.Wallet(process.env.SIGNER_PRIVATE_KEY!, provider);
+  }
+  return signer;
 }
 
 const weiFactor = BigInt(10 ** 10);

--- a/src/utils/transactionQueue.ts
+++ b/src/utils/transactionQueue.ts
@@ -1,0 +1,38 @@
+type QueueItem = {
+  execute: () => Promise<void>;
+};
+
+class TransactionQueue {
+  private readonly queue: QueueItem[] = [];
+  private processing = false;
+
+  async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({
+        execute: async () => {
+          try {
+            const result = await fn();
+            resolve(result);
+          } catch (error) {
+            reject(error);
+          }
+        },
+      });
+      this.process();
+    });
+  }
+
+  private async process(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const item = this.queue.shift()!;
+      await item.execute();
+    }
+
+    this.processing = false;
+  }
+}
+
+export const transactionQueue = new TransactionQueue();


### PR DESCRIPTION
## Summary

- Add transaction queue to serialize all claim transactions
- Prevents "already known" and "nonce too low" errors caused by parallel claims
- Use singleton signer instance for consistency

## Problem

Parallel claim transactions (auto-claim + API) were fetching the same nonce from the node simultaneously, causing:
- `"already known"` - same transaction sent twice
- `"nonce too low"` - transaction with used nonce

## Solution

A minimal transaction queue that processes all transactions sequentially:

```
BEFORE:  Claim A ──┬──► Nonce 119 ──► Conflict!
         Claim B ──┘

AFTER:   Claim A ──► Queue ──► Nonce 119 ──► OK
         Claim B ─────────────► Nonce 120 ──► OK
```

## Changes

- `src/utils/transactionQueue.ts` - New queue class (~35 lines)
- `src/utils/evm.ts` - Singleton signer with `getSigner()`
- `src/utils/autoClaim.ts` - Wrap claims in queue
- `src/api/routes.ts` - Wrap claims in queue

## Test plan

- [ ] Deploy to staging and verify no more nonce conflicts
- [ ] Test concurrent claims via API and auto-claim