### PR TITLE
fix: add transaction queue to prevent nonce conflicts (#15)

### DIFF
--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -2,9 +2,13 @@ import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider(process.env.RPC_PROVIDER_URL!);
 
-export function createSigner(privateKey: string) {
-  const wallet = new ethers.Wallet(privateKey);
-  return wallet.connect(provider);
+let signer: ethers.Wallet | null = null;
+
+export function getSigner(): ethers.Wallet {
+  if (!signer) {
+    signer = new ethers.Wallet(process.env.SIGNER_PRIVATE_KEY!, provider);
+  }
+  return signer;
 }
 
 const weiFactor = BigInt(10 ** 10);

--- a/src/utils/transactionQueue.ts
+++ b/src/utils/transactionQueue.ts
@@ -1,0 +1,38 @@
+type QueueItem = {
+  execute: () => Promise<void>;
+};
+
+class TransactionQueue {
+  private readonly queue: QueueItem[] = [];
+  private processing = false;
+
+  async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({
+        execute: async () => {
+          try {
+            const result = await fn();
+            resolve(result);
+          } catch (error) {
+            reject(error);
+          }
+        },
+      });
+      this.process();
+    });
+  }
+
+  private async process(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const item = this.queue.shift()!;
+      await item.execute();
+    }
+
+    this.processing = false;
+  }
+}
+
+export const transactionQueue = new TransactionQueue();


### PR DESCRIPTION
Parallel claim transactions were causing "already known" and "nonce too low" errors because they fetched the same nonce from the node simultaneously.

Changes:
- Add TransactionQueue class that serializes all transactions
- Use singleton signer instance for consistency
- Wrap claim logic in queue for both auto-claim and API endpoint