### PR TITLE
fix: handle race conditions in help-me-claim API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ ponder.on("CoinSwapAbi:Lockup", async ({ event, context }) => {
       .then((result) => {
         if (result.success) {
           console.log(`Auto-claim successful for ${event.args.preimageHash}: ${result.txHash}`);
+        } else if (result.error?.includes("no Ether locked") || result.error?.includes("no tokens locked")) {
+          console.log(`Auto-claim skipped for ${event.args.preimageHash}: already claimed`);
         } else {
           console.error(`Auto-claim failed for ${event.args.preimageHash}: ${result.error}`);
         }
@@ -79,6 +81,8 @@ ponder.on("ERC20SwapCitrea:Lockup", async ({ event, context }) => {
       .then((result) => {
         if (result.success) {
           console.log(`Auto-claim successful for ${event.args.preimageHash}: ${result.txHash}`);
+        } else if (result.error?.includes("no Ether locked") || result.error?.includes("no tokens locked")) {
+          console.log(`Auto-claim skipped for ${event.args.preimageHash}: already claimed`);
         } else {
           console.error(`Auto-claim failed for ${event.args.preimageHash}: ${result.error}`);
         }


### PR DESCRIPTION
## Summary

- Remove claimed/refunded filter from initial query to detect already claimed swaps
- Return existing txHash when swap is already claimed (instead of 404)
- Add `waitForClaimedLockup()` function to handle race condition when Auto-Claim finished but Claim Event not yet indexed
- Retry up to 3 times with 2s delay when "no tokens/Ether locked" error occurs
- Log INFO instead of ERROR when Auto-Claim is skipped due to already claimed swap

## Problem

When Auto-Claim and the bapp both try to claim a swap, race conditions can occur:

1. **Auto-Claim finishes first**: bapp calls `helpMeClaim`, but Claim Event not yet indexed → 404 error
2. **bapp finishes first**: Auto-Claim tries to claim → "no tokens locked" error logged as ERROR

## Solution

- The bapp now always receives the correct `txHash` regardless of who claims first
- Auto-Claim logs INFO instead of ERROR when swap was already claimed
- Added retry mechanism with 6s max wait for Claim Event to be indexed

## Test plan

- [ ] Test Auto-Claim followed by bapp helpMeClaim
- [ ] Test bapp helpMeClaim followed by Auto-Claim
- [ ] Verify no ERROR logs for "already claimed" scenarios
- [ ] Verify bapp receives txHash in all success cases