### PR TITLE
fix: remove lockup polling from help-me-claim

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -19,18 +19,6 @@ import { scheduledClaims } from "../../offchain";
 const createLockupId = (chainId: number, preimageHash: string) =>
   `${chainId}:${preimageHash}`;
 
-async function waitForLockup(
-  lockupId: string,
-  { attempts = 3, delayMs = 2000 } = {}
-): Promise<(typeof lockups.$inferSelect) | undefined> {
-  for (let i = 0; i < attempts; i++) {
-    const result = await db.select().from(lockups).where(eq(lockups.id, lockupId)).limit(1);
-    if (result[0]) return result[0];
-    if (i < attempts - 1) await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-  return undefined;
-}
-
 const TX_WAIT_TIMEOUT_MS = 40_000;
 
 const routes = new Hono();
@@ -167,7 +155,8 @@ routes.post("/help-me-claim", async (c: Context) => {
 
   const normalizedHash = prefix0x(preimageHash);
   const lockupId = createLockupId(chainId, normalizedHash);
-  const lockupData = await waitForLockup(lockupId);
+  const lockupResult = await db.select().from(lockups).where(eq(lockups.id, lockupId)).limit(1);
+  const lockupData = lockupResult[0];
 
   if (!lockupData) {
     return c.json({ error: "Lockup not found" }, 404);


### PR DESCRIPTION
## Summary
- remove retry-based lockup polling from `POST /help-me-claim`
- perform a single immediate lockup lookup and return `404` if not indexed
- reduce request latency and avoid server-side wait behavior

## Test plan
- [ ] Call `POST /help-me-claim` for an indexed lockup and verify behavior is unchanged
- [ ] Call `POST /help-me-claim` before indexer catches up and verify immediate `404`
- [ ] Confirm route still validates `preimageHash`, `preimage`, and `chainId`