### PR TITLE
ci: switch boltz-claim image to lightningdotspacecom (ARM64-only)

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,18 +1,22 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image (manual)
+
+# Manual ad-hoc build that pushes the current branch as
+# lightningdotspacecom/boltz-claim:beta. Useful for testing branches
+# without going through develop/main. The regular DEV/PRD pipelines
+# live in ci-dev.yml and ci-prd.yml.
 
 on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/boltz-claim:beta
+  DOCKER_TAGS: lightningdotspacecom/boltz-claim:beta
 
 jobs:
   build-and-push:
-    name: Build and Push Docker Image
+    name: Build and Push Docker Image (linux/arm64)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,6 +26,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU (arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,8 +43,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          provenance: false
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
             NODE_ENV=production

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -11,12 +11,13 @@ on:
 env:
   DOCKER_TAGS: lightningdotspacecom/boltz-claim:beta
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
-    name: Build and Push Docker Image (linux/arm64)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    name: Build and push (linux/arm64)
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,11 +27,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU (arm64)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,10 +39,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          provenance: false
+          platforms: linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
             NODE_ENV=production

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,4 +1,4 @@
-name: Boltz Claim DEV CI/CD
+name: LDS Boltz Claim DEV CI/CD
 
 on:
   push:
@@ -8,12 +8,13 @@ on:
 env:
   DOCKER_TAGS: lightningdotspacecom/boltz-claim:beta
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image (linux/arm64)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+  build-and-deploy:
+    name: Build and deploy to DEV
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,11 +24,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU (arm64)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -40,9 +36,24 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          provenance: false
+          platforms: linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            "lds-boltz-claim"

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -6,17 +6,14 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/boltz-claim:beta
-  AZURE_RESOURCE_GROUP: rg-lds-api-dev
-  AZURE_VM_NAME: vm-lds-btc-dev
+  DOCKER_TAGS: lightningdotspacecom/boltz-claim:beta
 
 jobs:
   build-and-push:
-    name: Build and Push Docker Image
+    name: Build and Push Docker Image (linux/arm64)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,6 +23,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU (arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,29 +40,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          provenance: false
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
-
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.LDS_DEV_CREDENTIALS }}
-
-      - name: Update Azure VM docker container
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Update docker container..."
-
-            az vm run-command invoke \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_VM_NAME }} \
-              --command-id RunShellScript \
-              --scripts "/home/lds/update-boltz.sh claim"
-
-      - name: Logout from Azure
-        if: always()
-        run: |
-          az logout

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -1,4 +1,4 @@
-name: Boltz Claim PRD CI/CD
+name: LDS Boltz Claim PRD CI/CD
 
 on:
   push:
@@ -8,12 +8,13 @@ on:
 env:
   DOCKER_TAGS: lightningdotspacecom/boltz-claim:latest
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image (linux/arm64)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+  build-and-deploy:
+    name: Build and deploy to PRD
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,11 +24,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU (arm64)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -40,9 +36,24 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          provenance: false
+          platforms: linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "lds-boltz-claim"

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -6,17 +6,14 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/boltz-claim:latest
-  AZURE_RESOURCE_GROUP: rg-lds-api-prd
-  AZURE_VM_NAME: vm-lds-btc-prd
+  DOCKER_TAGS: lightningdotspacecom/boltz-claim:latest
 
 jobs:
   build-and-push:
-    name: Build and Push Docker Image
+    name: Build and Push Docker Image (linux/arm64)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,6 +23,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU (arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,30 +40,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          provenance: false
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
-            NODE_ENV=production
-
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.LDS_PRD_CREDENTIALS }}
-
-      - name: Update Azure VM docker container
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Update docker container..."
-
-            az vm run-command invoke \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_VM_NAME }} \
-              --command-id RunShellScript \
-              --scripts "/home/lds/update-boltz.sh claim"
-
-      - name: Logout from Azure
-        if: always()
-        run: |
-          az logout


### PR DESCRIPTION
## Summary

Prep for Stage 2 of the lightning.space migration off Azure to the DFX (ARM64) infrastructure. Aligned with the existing DFX CI convention (cf. `juicedollarcom/api`, `deurocom/api`).

**Image pipelines:**

- `dfxswiss/boltz-claim:{beta,latest}` → `lightningdotspacecom/boltz-claim:{beta,latest}`
- `runs-on: ubuntu-24.04-arm` (native ARM, no QEMU)
- `platforms: linux/arm64`
- Removed Azure VM update step from both workflows — the LDS Azure VM is being decommissioned
- New deploy step: install `cloudflared`, SSH via Cloudflare Tunnel, invoke `deploy.sh` with service name `lds-boltz-claim`. The matching `case` block lives in `DFXServer/server` (commit `ba6fdf6`).
- `build-push-docker.yml` (manual ad-hoc build) brought to the same convention.
- Workflow names prefixed with `LDS` for consistency with the rest of the LightningDotSpace stack pipelines.

## Required secrets before merge

| Secret | Purpose |
|---|---|
| `DOCKER_USERNAME`, `DOCKER_PASSWORD` | Docker Hub token with **write access to the `lightningdotspacecom` org** |
| `DEPLOY_DEV_*`, `DEPLOY_PRD_*` | SSH-deploy via Cloudflare Tunnel to dfxdev/dfxprd (4 keys each, see workflow file) |

The deploy step will fail until `dfxdev:~/lds/docker-compose.yaml` is in place — image still gets pushed to Docker Hub.

## Test plan

- [ ] `workflow_dispatch` on `ci-dev.yml` builds and pushes `lightningdotspacecom/boltz-claim:beta`
- [ ] Pull the resulting image on an arm64 host, confirm the container starts